### PR TITLE
[TASK] Add model for backend sessions

### DIFF
--- a/Classes/Domain/Model/Session.php
+++ b/Classes/Domain/Model/Session.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types = 1);
+
+namespace Ssch\Typo3AliceFixtures\Domain\Model;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+final class Session implements DataHandlerObjectInterface
+{
+    use DataHandlerObjectTrait;
+
+    public function getTableName(): string
+    {
+        return 'be_sessions';
+    }
+}

--- a/Classes/Domain/Model/Session.php
+++ b/Classes/Domain/Model/Session.php
@@ -20,8 +20,19 @@ final class Session implements DataHandlerObjectInterface
 {
     use DataHandlerObjectTrait;
 
+    const TABLE_NAME = 'be_sessions';
+
     public function getTableName(): string
     {
-        return 'be_sessions';
+        return self::TABLE_NAME;
+    }
+
+    public function getUid()
+    {
+        if (! isset($this->data['ses_id'])) {
+            $this->data['ses_id'] = md5(time() + rand());
+        }
+
+        return $this->data['ses_id'];
     }
 }

--- a/Classes/Loader/AppendLoaderFactory.php
+++ b/Classes/Loader/AppendLoaderFactory.php
@@ -36,8 +36,7 @@ final class AppendLoaderFactory implements LoaderFactoryInterface
      */
     private $persister;
 
-    public function __construct(FileProcessor $fileProcessor, DataHandlerPersister $persister)
-    {
+    public function __construct(FileProcessor $fileProcessor, DataHandlerPersister $persister) {
         $this->processors[] = $fileProcessor;
         $this->persister = $persister;
     }

--- a/Classes/Persister/DataHandlerPersister.php
+++ b/Classes/Persister/DataHandlerPersister.php
@@ -20,8 +20,10 @@ use Fidry\AliceDataFixtures\Persistence\PersisterInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Ssch\Typo3AliceFixtures\Domain\Model\DataHandlerObjectInterface;
-use Ssch\Typo3AliceFixtures\Domain\Model\File;
+use Ssch\Typo3AliceFixtures\Domain\Model\Session;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Session\Backend\DatabaseSessionBackend;
+use TYPO3\CMS\Core\Session\Backend\Exception\SessionNotCreatedException;
 use UnexpectedValueException;
 
 final class DataHandlerPersister implements PersisterInterface
@@ -38,13 +40,27 @@ final class DataHandlerPersister implements PersisterInterface
     private $dataMap = [];
 
     /**
+     * @var DatabaseSessionBackend
+     */
+    private $databaseSessionBackend;
+
+    /**
+     * @var Session[] Backend sessions are processed after flush happened as IDs need to be available
+     */
+    private $backendSessionsQueue = [];
+
+    /**
      * @var LoggerInterface
      */
     private $logger;
 
-    public function __construct(DataHandler $dataHandler, LoggerInterface $logger = null)
-    {
+    public function __construct(
+        DataHandler $dataHandler,
+        DatabaseSessionBackend $databaseSessionBackend,
+        LoggerInterface $logger = null
+    ) {
         $this->dataHandler = $dataHandler;
+        $this->databaseSessionBackend = $databaseSessionBackend;
         $this->logger = $logger ?: new NullLogger();
     }
 
@@ -55,6 +71,14 @@ final class DataHandlerPersister implements PersisterInterface
     {
         if (! $object instanceof DataHandlerObjectInterface) {
             throw new UnexpectedValueException('Must be of type DataHandlerObjectInterface');
+        }
+
+        /**
+         * Add backend sessions to queue as they are persisted after flush happened
+         */
+        if ($object instanceof Session) {
+            $this->backendSessionsQueue[] = $object;
+            return;
         }
 
         $this->dataMap[$object->getTableName()][$object->getUid()] = $object->toArray();
@@ -76,6 +100,35 @@ final class DataHandlerPersister implements PersisterInterface
             }
 
             $this->dataMap = [];
+        }
+
+        // Process backend sessions
+        if (count($this->backendSessionsQueue)) {
+            $this->databaseSessionBackend->initialize('default', ['table' => Session::TABLE_NAME]);
+            foreach ($this->backendSessionsQueue as $object) {
+                // Default values from typo3/testing-framework package
+                $data = array_merge(
+                    [
+                        'ses_iplock' => '[DISABLED]',
+                        'ses_backuserid' => 0,
+                        'ses_data' => '',
+                        'ses_tstamp' => 1777777777
+                    ],
+                    $object->toArray()
+                );
+
+                // Replace placeholder id with generated id
+                $sessUserId = $data['ses_userid'];
+                if (array_key_exists($sessUserId, $this->dataHandler->substNEWwithIDs)) {
+                    $data['ses_userid'] = $this->dataHandler->substNEWwithIDs[$sessUserId];
+                }
+
+                try {
+                    $this->databaseSessionBackend->set($object->getUid(), $data);
+                } catch (SessionNotCreatedException $error) {
+                    $this->logger->error($error);
+                }
+            }
         }
     }
 }

--- a/Tests/Functional/Fixtures/fixtures/0002_backend_session.yaml
+++ b/Tests/Functional/Fixtures/fixtures/0002_backend_session.yaml
@@ -1,0 +1,6 @@
+\Ssch\Typo3AliceFixtures\Domain\Model\Session:
+  session_user1:
+    ses_id: '886526ce72b86870739cc41991144ec1'
+    ses_userid: '@user_1'
+    ses_iplock: '[DISABLED]'
+    ses_tstamp: 1777777777

--- a/Tests/Functional/Fixtures/fixtures/0002_backend_session.yaml
+++ b/Tests/Functional/Fixtures/fixtures/0002_backend_session.yaml
@@ -2,5 +2,3 @@
   session_user1:
     ses_id: '886526ce72b86870739cc41991144ec1'
     ses_userid: '@user_1'
-    ses_iplock: '[DISABLED]'
-    ses_tstamp: 1777777777


### PR DESCRIPTION
Session fixtures are used in the [TYPO3 testing framework](https://github.com/TYPO3/testing-framework) for a quick login instead of entering the account information every time at the beginning of a test.

See fixtures at testing package here: https://github.com/TYPO3/testing-framework/blob/master/Resources/Core/Acceptance/Fixtures/be_sessions.xml